### PR TITLE
Add Harbor-hub export (fetch-at-build, no hosted image)

### DIFF
--- a/docker/Dockerfile.harbor
+++ b/docker/Dockerfile.harbor
@@ -1,18 +1,23 @@
-# Self-contained chi-Bench Harbor task environment (route X: fetch-at-build).
+# Self-contained chi-Bench Harbor task environment (fetch-at-build).
 #
 # Unlike chi-bench/docker/Dockerfile (which COPYs code+data from the repo
-# root build context), this Dockerfile builds with NO repo checkout: it
-# fetches the chi_bench package from GitHub and the fixtures/worlds +
-# handbook from Hugging Face at build time. Harbor builds it on `harbor run`
-# from the task archive alone — no hosted/registry image required.
+# root build context), this builds with NO repo checkout and needs no hosted
+# image. Harbor builds it on `harbor run` from the task archive alone:
+#   - BUILD time (secret-free): clone chi_bench from GitHub + download the
+#     public fixtures/worlds dataset (actava/chi-bench) from Hugging Face.
+#   - RUNTIME (wrapper entrypoint): download the GATED managed-care handbook
+#     (actava/managed-care-operations-handbook) using HF_TOKEN from the
+#     container env, then hand off to the real chi-bench entrypoint.
 #
 # Per-task selection is via CHI_BENCH_TASK_ID, injected from task.toml
-# [environment.env]; this file is IDENTICAL across all 101 tasks.
+# [environment.env]; this file is IDENTICAL across all tasks.
 #
-# PREREQUISITE: actava/chi-bench AND actava/managed-care-operations-handbook
-# must be PUBLIC on HF, so the `hf download` calls need no token (Harbor
-# task builds do not pass build secrets). If either stays gated, builders
-# must supply HF_TOKEN as a buildkit secret.
+# Why runtime (not build) for the handbook: Harbor's docker environment build
+# passes NO build secrets, and the handbook is gated:manual on HF — a
+# build-time `hf download` would 401. Fetching it in the entrypoint lets
+# Harbor forward an approved HF_TOKEN as a normal runtime env var. Running
+# therefore requires handbook access:
+#   harbor run -d actava-ai/chi-bench@<tag> -a <agent> -e HF_TOKEN=<token>
 
 # syntax=docker/dockerfile:1.7
 FROM python:3.12-slim AS base
@@ -52,12 +57,14 @@ RUN git clone --depth 1 --branch "${CHI_BENCH_REF}" \
     && /workspace/.venv/bin/playwright install --with-deps chromium 2>/dev/null \
        || python -m playwright install --with-deps chromium
 
-# --- 2. fixtures/worlds + handbook from Hugging Face (must be PUBLIC) ---
+# --- 2. fixtures/worlds from Hugging Face (public dataset) ---
+# The managed-care handbook (actava/managed-care-operations-handbook) is GATED.
+# Harbor's docker environment build passes no build secrets, so the handbook
+# canNOT be fetched at build time — it is downloaded at RUNTIME by the wrapper
+# entrypoint using HF_TOKEN from the container env (see harbor-entrypoint).
 ARG CHI_BENCH_DATASET_REV=chi-bench-v1.0.0
 RUN hf download actava/chi-bench --repo-type dataset --revision "${CHI_BENCH_DATASET_REV}" \
-        --local-dir /tmp/chi-bench-data \
-    && hf download actava/managed-care-operations-handbook --repo-type dataset \
-        --local-dir /workspace/skills/managed-care-operations-handbook
+        --local-dir /tmp/chi-bench-data
 
 # --- 3. arrange data into the layout the server + entrypoint expect ---
 #     (mirrors chi-bench/docker/Dockerfile runtime stage, lines 82-92)
@@ -78,6 +85,27 @@ RUN mkdir -p /opt/chi-bench/worlds /opt/chi-bench/tasks /opt/chi-bench-task-asse
 RUN echo 'export PATH="/workspace/.venv/bin:$PATH"' > /etc/profile.d/chi-bench.sh \
     && mkdir -p /logs/artifacts
 
+# Wrapper entrypoint: the handbook is gated and not baked at build, so fetch it
+# at container start using HF_TOKEN from the runtime env (Harbor forwards env
+# vars but not build secrets), then hand off to the real chi-bench entrypoint.
+RUN printf '%s\n' \
+    '#!/bin/sh' \
+    'set -e' \
+    'HB=/workspace/skills/managed-care-operations-handbook' \
+    'if [ ! -d "$HB" ] || [ -z "$(ls -A "$HB" 2>/dev/null)" ]; then' \
+    '  TOKEN="${HF_TOKEN:-${HUGGING_FACE_HUB_TOKEN:-}}"' \
+    '  if [ -z "$TOKEN" ]; then' \
+    '    echo "harbor-entrypoint: gated handbook missing and no HF_TOKEN in env." >&2' \
+    '    echo "chi-bench is gated; run with: harbor run -d actava-ai/chi-bench ... -e HF_TOKEN=<approved-token>" >&2' \
+    '    exit 78' \
+    '  fi' \
+    '  echo "harbor-entrypoint: fetching gated handbook at runtime..." >&2' \
+    '  HF_TOKEN="$TOKEN" hf download actava/managed-care-operations-handbook --repo-type dataset --local-dir /workspace/skills >&2' \
+    'fi' \
+    'exec /usr/local/bin/entrypoint.sh "$@"' \
+    > /usr/local/bin/harbor-entrypoint.sh \
+    && chmod +x /usr/local/bin/harbor-entrypoint.sh
+
 ENV CHI_BENCH_RUNTIME_DIR=/tmp/chi-bench-runtime \
     CHI_BENCH_WORLDS_DIR=/opt/chi-bench/worlds \
     CHI_BENCH_PAYER_MODE=agent \
@@ -86,5 +114,5 @@ ENV CHI_BENCH_RUNTIME_DIR=/tmp/chi-bench-runtime \
     IS_SANDBOX=1
 
 EXPOSE 8020 8023 8100 8200
-ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/entrypoint.sh"]
+ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/harbor-entrypoint.sh"]
 CMD ["sleep", "infinity"]

--- a/docker/Dockerfile.harbor
+++ b/docker/Dockerfile.harbor
@@ -1,0 +1,90 @@
+# Self-contained chi-Bench Harbor task environment (route X: fetch-at-build).
+#
+# Unlike chi-bench/docker/Dockerfile (which COPYs code+data from the repo
+# root build context), this Dockerfile builds with NO repo checkout: it
+# fetches the chi_bench package from GitHub and the fixtures/worlds +
+# handbook from Hugging Face at build time. Harbor builds it on `harbor run`
+# from the task archive alone — no hosted/registry image required.
+#
+# Per-task selection is via CHI_BENCH_TASK_ID, injected from task.toml
+# [environment.env]; this file is IDENTICAL across all 101 tasks.
+#
+# PREREQUISITE: actava/chi-bench AND actava/managed-care-operations-handbook
+# must be PUBLIC on HF, so the `hf download` calls need no token (Harbor
+# task builds do not pass build secrets). If either stays gated, builders
+# must supply HF_TOKEN as a buildkit secret.
+
+# syntax=docker/dockerfile:1.7
+FROM python:3.12-slim AS base
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    UV_LINK_MODE=copy \
+    UV_PROJECT_ENVIRONMENT=/workspace/.venv \
+    PATH="/workspace/.venv/bin:${PATH}"
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates curl git tini \
+    && rm -rf /var/lib/apt/lists/*
+
+# judge-harness:claude-code  — Node 20 + Claude Code CLI (verifier phase)
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl ca-certificates \
+    && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && npm install -g @anthropic-ai/claude-code@latest \
+    && command -v claude \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /workspace
+RUN pip install --no-cache-dir uv "huggingface_hub[cli]"
+
+# --- 1. chi_bench code from the public GitHub repo (pin to a tag/sha) ---
+ARG CHI_BENCH_REF=main
+RUN git clone --depth 1 --branch "${CHI_BENCH_REF}" \
+        https://github.com/actava-ai/chi-bench /workspace/chi-bench-src \
+    && cp /workspace/chi-bench-src/pyproject.toml /workspace/chi-bench-src/uv.lock /workspace/ \
+    && cp -r /workspace/chi-bench-src/src /workspace/src \
+    && cp /workspace/chi-bench-src/docker/entrypoint.sh /usr/local/bin/entrypoint.sh \
+    && chmod +x /usr/local/bin/entrypoint.sh \
+    && (uv sync --no-dev || pip install --no-cache-dir /workspace/chi-bench-src) \
+    && /workspace/.venv/bin/playwright install --with-deps chromium 2>/dev/null \
+       || python -m playwright install --with-deps chromium
+
+# --- 2. fixtures/worlds + handbook from Hugging Face (must be PUBLIC) ---
+ARG CHI_BENCH_DATASET_REV=chi-bench-v1.0.0
+RUN hf download actava/chi-bench --repo-type dataset --revision "${CHI_BENCH_DATASET_REV}" \
+        --local-dir /tmp/chi-bench-data \
+    && hf download actava/managed-care-operations-handbook --repo-type dataset \
+        --local-dir /workspace/skills/managed-care-operations-handbook
+
+# --- 3. arrange data into the layout the server + entrypoint expect ---
+#     (mirrors chi-bench/docker/Dockerfile runtime stage, lines 82-92)
+RUN mkdir -p /opt/chi-bench/worlds /opt/chi-bench/tasks /opt/chi-bench-task-assets \
+    && D=/tmp/chi-bench-data \
+    && cp -r "$D"/prior_auth_provider/shared/worlds/. /opt/chi-bench/worlds/ 2>/dev/null || true \
+    && cp -r "$D"/prior_auth_um/shared/worlds/.       /opt/chi-bench/worlds/ 2>/dev/null || true \
+    && cp -r "$D"/care_management/shared/worlds/.     /opt/chi-bench/worlds/ 2>/dev/null || true \
+    && cp -r "$D"/prior_auth_e2e/worlds/.             /opt/chi-bench/worlds/ 2>/dev/null || true \
+    && cp -r "$D"/prior_auth_provider/tasks/.         /opt/chi-bench/tasks/  2>/dev/null || true \
+    && cp -r "$D"/prior_auth_um/tasks/.               /opt/chi-bench/tasks/  2>/dev/null || true \
+    && cp -r "$D"/care_management/tasks/.             /opt/chi-bench/tasks/  2>/dev/null || true \
+    && cp -r "$D"/prior_auth_e2e/tasks/.              /opt/chi-bench/tasks/  2>/dev/null || true \
+    && cp -r "$D"/marathon                            /opt/chi-bench/tasks/marathon 2>/dev/null || true \
+    && cp "$D"/care_management/shared/tool_reference.md /opt/chi-bench-task-assets/tool_reference.md 2>/dev/null || true \
+    && rm -rf /tmp/chi-bench-data
+
+RUN echo 'export PATH="/workspace/.venv/bin:$PATH"' > /etc/profile.d/chi-bench.sh \
+    && mkdir -p /logs/artifacts
+
+ENV CHI_BENCH_RUNTIME_DIR=/tmp/chi-bench-runtime \
+    CHI_BENCH_WORLDS_DIR=/opt/chi-bench/worlds \
+    CHI_BENCH_PAYER_MODE=agent \
+    CHI_BENCH_WORKSPACE_ROOT=/logs/artifacts/workspaces \
+    CHI_BENCH_RAW_ROOT=/srv/chi-bench/raw \
+    IS_SANDBOX=1
+
+EXPOSE 8020 8023 8100 8200
+ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/entrypoint.sh"]
+CMD ["sleep", "infinity"]

--- a/docs/harbor-hub.md
+++ b/docs/harbor-hub.md
@@ -8,24 +8,38 @@ as `actava-ai/chi-bench` so Harbor users can discover and run it with
 
 The hub does **not** host a chi-Bench image and chi-Bench does **not** push one
 to any registry. Instead, each exported task ships a self-contained
-`environment/Dockerfile` (`docker/Dockerfile.harbor`) that, at build time:
+`environment/Dockerfile` (`docker/Dockerfile.harbor`):
 
+**At build time** (Harbor builds the image on `harbor run`, secret-free):
 1. `git clone`s the `chi_bench` package from this public GitHub repo;
-2. `hf download`s the task fixtures/worlds (`actava/chi-bench`) and the
-   managed-care handbook (`actava/managed-care-operations-handbook`) from
-   Hugging Face;
-3. arranges them into the `/opt/chi-bench` layout the server + entrypoint
-   expect.
+2. `hf download`s the task fixtures/worlds from the public dataset
+   (`actava/chi-bench`);
+3. arranges them into the `/opt/chi-bench` layout the server expects.
 
-Harbor builds this image on `harbor run` from the task archive alone. The
-trial is selected by `CHI_BENCH_TASK_ID` (set in `task.toml [environment.env]`),
-so the Dockerfile is **identical across all tasks**.
+**At container start** (wrapper entrypoint, `harbor-entrypoint.sh`):
+4. downloads the **gated** managed-care handbook
+   (`actava/managed-care-operations-handbook`) into
+   `/workspace/skills/` using `HF_TOKEN` from the container env, then hands off
+   to the real chi-Bench entrypoint.
 
-> **Prerequisite:** both `actava/chi-bench` and
-> `actava/managed-care-operations-handbook` must be **public** on Hugging Face —
-> Harbor task builds do not pass build secrets, so the `hf download` calls must
-> need no token. If the handbook is gated, builders must supply `HF_TOKEN` as a
-> BuildKit secret.
+The trial is selected by `CHI_BENCH_TASK_ID` (set in
+`task.toml [environment.env]`), so the Dockerfile is **identical across all
+tasks**.
+
+> **Why the handbook is fetched at runtime, not build time.** Harbor's docker
+> environment builds from a compose file with only `build: context` — it passes
+> **no build secrets**. The handbook is `gated: manual` on HF, so a build-time
+> `hf download` would 401 with no way to inject a token. Fetching it in the
+> entrypoint lets Harbor forward an approved `HF_TOKEN` as a normal runtime env
+> var instead.
+>
+> **Running therefore requires handbook access:**
+> ```bash
+> harbor run -d actava-ai/chi-bench@<tag> -a <agent> -m <model> \
+>     -e HF_TOKEN=<your-approved-hf-token>
+> ```
+> Without an approved token the container exits early with a clear message.
+> The public dataset (`actava/chi-bench`) needs no token.
 
 ## What ships in a hub task (and what does not)
 

--- a/docs/harbor-hub.md
+++ b/docs/harbor-hub.md
@@ -1,0 +1,66 @@
+# Publishing chi-Bench to the Harbor hub
+
+chi-Bench is listed on the [Harbor hub](https://hub.harborframework.com/datasets/actava-ai/chi-bench)
+as `actava-ai/chi-bench` so Harbor users can discover and run it with
+`harbor run -d actava-ai/chi-bench@<tag>`.
+
+## How hub tasks run (fetch-at-build, no hosted image)
+
+The hub does **not** host a chi-Bench image and chi-Bench does **not** push one
+to any registry. Instead, each exported task ships a self-contained
+`environment/Dockerfile` (`docker/Dockerfile.harbor`) that, at build time:
+
+1. `git clone`s the `chi_bench` package from this public GitHub repo;
+2. `hf download`s the task fixtures/worlds (`actava/chi-bench`) and the
+   managed-care handbook (`actava/managed-care-operations-handbook`) from
+   Hugging Face;
+3. arranges them into the `/opt/chi-bench` layout the server + entrypoint
+   expect.
+
+Harbor builds this image on `harbor run` from the task archive alone. The
+trial is selected by `CHI_BENCH_TASK_ID` (set in `task.toml [environment.env]`),
+so the Dockerfile is **identical across all tasks**.
+
+> **Prerequisite:** both `actava/chi-bench` and
+> `actava/managed-care-operations-handbook` must be **public** on Hugging Face —
+> Harbor task builds do not pass build secrets, so the `hf download` calls must
+> need no token. If the handbook is gated, builders must supply `HF_TOKEN` as a
+> BuildKit secret.
+
+## What ships in a hub task (and what does not)
+
+Each task archive contains only `task.toml`, `instruction.md`,
+`environment/Dockerfile`, `tests/test.sh`, and `README.md`. It carries **no
+`solution/`, no `fixtures/`, no expectations** — the scoring contract is baked
+into the image at build time and the entrypoint deliberately withholds it from
+the agent (no `/fixtures` symlink).
+
+The verifier runs in the same container during Harbor's verifier phase:
+
+- standard tasks: `python -m chi_bench.verifier.task_runtime verify --expectations-path /opt/chi-bench/tasks/$CHI_BENCH_TASK_ID/fixtures/expectations.json`
+- marathon sessions: `python -m chi_bench.verifier.session_verifier --fixtures-dir … --output-dir /logs/verifier` (their `CHI_BENCH_TASK_ID` is the slash path `marathon/<domain>`).
+
+Both write the binary reward to `/logs/verifier/reward.json`.
+
+## Regenerating + publishing
+
+```bash
+# 1. Export 101 self-contained Harbor task dirs from the dataset tree
+uv run python scripts/export_harbor_tasks.py \
+    --data-root data --out logs/harbor_export --org actava-ai
+
+# 2. Build the dataset manifest + publish (tasks first, then the dataset)
+cd logs/harbor_export
+uvx harbor auth login                       # one-time, GitHub flow
+uvx harbor init "actava-ai/chi-bench" --dataset --description "…" --author "actava-ai"
+uvx harbor add tasks --scan
+uvx harbor publish tasks --private          # publish the 101 task packages
+uvx harbor publish . -t v1.0.0 --private --no-tasks   # publish the dataset
+# verify the listing, then flip to public:
+#   uvx harbor dataset visibility actava-ai/chi-bench --public
+```
+
+`--data-root` can point at a local HF clone of `actava/chi-bench`; it expects
+the `prior_auth_um/`, `prior_auth_provider/`, `care_management/`,
+`prior_auth_e2e/`, and `marathon/` families plus the optional `tasks.jsonl`
+metadata sidecar.

--- a/scripts/export_harbor_tasks.py
+++ b/scripts/export_harbor_tasks.py
@@ -1,0 +1,232 @@
+"""Export self-contained Harbor-hub task directories for chi-Bench.
+
+Each emitted task is runnable from the Harbor hub with no repo checkout and no
+hosted image: the per-task ``environment/Dockerfile`` (route X, fetch-at-build)
+clones chi_bench from GitHub and downloads fixtures+handbook from Hugging Face
+at build time, then selects the trial via ``CHI_BENCH_TASK_ID`` (set in
+``task.toml [environment.env]``). See ``docker/Dockerfile.harbor``.
+
+The task archive carries NO solution/, NO fixtures/, NO ground truth — the
+scoring contract is baked into the image at build time and the in-container
+entrypoint deliberately withholds it from the agent.
+
+Usage:
+    uv run python scripts/export_harbor_tasks.py \
+        --data-root data \
+        --out logs/harbor_export \
+        --org actava-ai
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DOCKERFILE = REPO_ROOT / "docker" / "Dockerfile.harbor"
+
+SOURCE_REPO = "https://github.com/actava-ai/chi-bench"
+HF_DATASET = "https://huggingface.co/datasets/actava/chi-bench"
+LEADERBOARD = "https://actava.ai/benchmarks/leaderboards"
+
+# (family dir, task glob, domain label). marathon tasks live directly under the
+# family dir (one self-contained session per domain), not under tasks/.
+FAMILIES = {
+    "prior_auth_um": ("prior_auth_um/tasks/*", "prior_auth_um"),
+    "prior_auth_provider": ("prior_auth_provider/tasks/*", "prior_auth_provider"),
+    "care_management": ("care_management/tasks/*", "care_management"),
+    "prior_auth_e2e": ("prior_auth_e2e/tasks/*", "prior_auth_e2e"),
+}
+MARATHON = {
+    "marathon/prior_auth_um": "marathon_prior_auth_um",
+    "marathon/prior_auth_provider": "marathon_prior_auth_provider",
+    "marathon/care_management": "marathon_care_management",
+}
+
+# Standard single-task verifier. CHI_BENCH_TASK_ID is in the persistent env
+# (task.toml [environment.env]); the scoring contract is baked at the
+# deterministic per-task path (the entrypoint deliberately does NOT expose
+# /fixtures to the agent, so we pass the path explicitly).
+TEST_SH = """\
+#!/usr/bin/env bash
+# chi-Bench verifier (same-container phase). The entrypoint has already booted
+# `cb serve` + the three MCP servers; this scores the agent's final world state
+# and writes the binary reward Harbor reads at /logs/verifier/reward.json.
+set -euo pipefail
+. /workspace/.venv/bin/activate
+mkdir -p /logs/verifier
+python -m chi_bench.verifier.task_runtime verify \\
+    --expectations-path "/opt/chi-bench/tasks/${CHI_BENCH_TASK_ID}/fixtures/expectations.json"
+"""
+
+# Marathon (long-horizon session) verifier: scores every sub-task in the
+# session and writes a session-level reward.json.
+SESSION_TEST_SH = """\
+#!/usr/bin/env bash
+set -euo pipefail
+. /workspace/.venv/bin/activate
+mkdir -p /logs/verifier
+python -m chi_bench.verifier.session_verifier \\
+    --fixtures-dir "/opt/chi-bench/tasks/${CHI_BENCH_TASK_ID}/fixtures" \\
+    --output-dir /logs/verifier
+"""
+
+README = """\
+# chi-Bench task — runs via fetch-at-build (no hosted image)
+
+This Harbor-hub task is self-contained: `environment/Dockerfile` clones
+chi_bench from {repo} and downloads fixtures + the managed-care handbook from
+Hugging Face at build time. No registry image, no repo checkout required.
+
+`harbor run -d {org}/chi-bench@<tag> ...` builds the image, boots the
+chi-Bench MCP servers, runs your agent, then scores with the baked-in verifier.
+
+- Source: {repo}
+- Dataset: {dataset}
+- Leaderboard: {leaderboard}
+"""
+
+
+def load_meta(data_root: Path) -> dict[str, dict]:
+    """Map task_id -> tasks.jsonl record, when present."""
+    f = data_root / "tasks.jsonl"
+    if not f.exists():
+        return {}
+    out = {}
+    for line in f.read_text().splitlines():
+        if line.strip():
+            r = json.loads(line)
+            out[r["task_id"]] = r
+    return out
+
+
+def render_task_toml(name: str, cb_task_id: str, domain: str, meta: dict) -> str:
+    title = meta.get("title", cb_task_id)
+    excerpt = (meta.get("instruction_excerpt") or "").replace("\n", " ").strip()[:180]
+    desc = f"chi-Bench {domain} task: {title}. {excerpt}".strip()
+    desc = desc.replace('"', "'")
+    kws = ["healthcare", "chi-bench", domain]
+    if meta.get("task_kind"):
+        kws.append(meta["task_kind"])
+    kw_toml = ", ".join(f'"{k}"' for k in kws)
+    agent_timeout = float(meta.get("agent_timeout_sec", 900.0))
+    return f"""\
+schema_version = "1.2"
+artifacts = []
+
+[task]
+name = "{name}"
+description = "{desc}"
+authors = []
+keywords = [{kw_toml}]
+
+[metadata]
+benchmark = "chi-bench"
+domain = "{domain}"
+source_repo = "{SOURCE_REPO}"
+dataset = "{HF_DATASET}"
+leaderboard = "{LEADERBOARD}"
+
+[verifier]
+timeout_sec = 1200.0
+
+[verifier.env]
+
+[agent]
+timeout_sec = {agent_timeout}
+
+[environment]
+build_timeout_sec = 2400.0
+os = "linux"
+cpus = 2
+memory_mb = 4096
+storage_mb = 10240
+gpus = 0
+allow_internet = true
+
+[environment.env]
+CHI_BENCH_TASK_ID = "{cb_task_id}"
+
+[[environment.mcp_servers]]
+name = "chi-bench-provider"
+transport = "streamable-http"
+url = "http://localhost:8020/mcp"
+
+[[environment.mcp_servers]]
+name = "chi-bench-payer"
+transport = "streamable-http"
+url = "http://localhost:8100/mcp"
+
+[[environment.mcp_servers]]
+name = "chi-bench-cm"
+transport = "streamable-http"
+url = "http://localhost:8200/mcp"
+"""
+
+
+def emit_task(
+    src: Path,
+    out_dir: Path,
+    name: str,
+    task_id: str,
+    cb_task_id: str,
+    domain: str,
+    meta: dict,
+    *,
+    session: bool = False,
+) -> None:
+    t = out_dir / task_id
+    (t / "environment").mkdir(parents=True, exist_ok=True)
+    (t / "tests").mkdir(parents=True, exist_ok=True)
+    (t / "task.toml").write_text(render_task_toml(name, cb_task_id, domain, meta))
+    instr = src / "instruction.md"
+    (t / "instruction.md").write_text(instr.read_text() if instr.exists() else f"# {task_id}\n")
+    shutil.copyfile(DOCKERFILE, t / "environment" / "Dockerfile")
+    ts = t / "tests" / "test.sh"
+    ts.write_text(SESSION_TEST_SH if session else TEST_SH)
+    ts.chmod(0o755)
+    (t / "README.md").write_text(
+        README.format(repo=SOURCE_REPO, org=name.split("/")[0], dataset=HF_DATASET, leaderboard=LEADERBOARD)
+    )
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--data-root", type=Path, default=REPO_ROOT / "data")
+    ap.add_argument("--out", type=Path, required=True)
+    ap.add_argument("--org", default="actava-ai")
+    args = ap.parse_args()
+
+    if not DOCKERFILE.exists():
+        raise SystemExit(f"missing {DOCKERFILE}")
+    meta = load_meta(args.data_root)
+    out_tasks = args.out / "tasks"
+    out_tasks.mkdir(parents=True, exist_ok=True)
+
+    n = 0
+    for _, (glob, domain) in FAMILIES.items():
+        for src in sorted(args.data_root.glob(glob)):
+            if not (src / "task.toml").exists() and not (src / "instruction.md").exists():
+                continue
+            tid = src.name
+            emit_task(src, out_tasks, f"{args.org}/{tid}", tid, tid, domain, meta.get(tid, {}))
+            n += 1
+    # marathon: hub name uses underscores; CHI_BENCH_TASK_ID is the in-image
+    # slash path (marathon/<domain>); scored by the session verifier.
+    for rel, tid in MARATHON.items():
+        src = args.data_root / rel
+        if src.exists():
+            emit_task(
+                src, out_tasks, f"{args.org}/{tid}", tid, rel, "marathon",
+                meta.get(tid, {}), session=True,
+            )
+            n += 1
+
+    print(f"Exported {n} Harbor tasks to {out_tasks}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/export_harbor_tasks.py
+++ b/scripts/export_harbor_tasks.py
@@ -80,8 +80,13 @@ This Harbor-hub task is self-contained: `environment/Dockerfile` clones
 chi_bench from {repo} and downloads fixtures + the managed-care handbook from
 Hugging Face at build time. No registry image, no repo checkout required.
 
-`harbor run -d {org}/chi-bench@<tag> ...` builds the image, boots the
-chi-Bench MCP servers, runs your agent, then scores with the baked-in verifier.
+The managed-care handbook is gated; the wrapper entrypoint downloads it at
+container start, so you must pass an approved HF token at run time:
+
+    harbor run -d {org}/chi-bench@<tag> -a <agent> -m <model> -e HF_TOKEN=<token>
+
+This builds the image, downloads the handbook, boots the chi-Bench MCP servers,
+runs your agent, then scores with the baked-in verifier.
 
 - Source: {repo}
 - Dataset: {dataset}


### PR DESCRIPTION
## What

Publishes chi-Bench to [hub.harborframework.com/datasets/actava-ai/chi-bench](https://hub.harborframework.com/datasets/actava-ai/chi-bench) as 101 **self-contained, runnable** Harbor tasks — **no hosted image, no registry**.

## How

`docker/Dockerfile.harbor` (identical across all 101 tasks; trial selected by `CHI_BENCH_TASK_ID` in `task.toml [environment.env]`):

- **Build (secret-free):** `git clone` chi_bench from this repo + `hf download` the public fixtures/worlds dataset (`actava/chi-bench`); arrange `/opt/chi-bench`.
- **Runtime (`harbor-entrypoint.sh`):** download the **gated** handbook (`actava/managed-care-operations-handbook`) into `/workspace/skills/` using `HF_TOKEN` from the container env — the same path the agent reads via `instruction.md` and the verifier reads via `cm_adapter` — then hand off to the real entrypoint.

`scripts/export_harbor_tasks.py` emits the 101 task dirs: `task.toml` + `instruction.md` + `environment/Dockerfile` + `tests/test.sh` + `README.md`. **No `solution/`, no `fixtures/`, no ground truth** in the archive. Standard tasks use `task_runtime verify`; marathon uses `session_verifier` (in-image path `marathon/<domain>`). Reward → `/logs/verifier/reward.json`.

## Why the handbook is fetched at runtime, not build

Harbor's docker environment builds from a compose file with only `build: context` — **no build secrets**. The handbook is `gated: manual` on HF, so a build-time `hf download` 401s with no way to inject a token. The entrypoint approach lets Harbor forward an approved `HF_TOKEN` as a normal runtime env var. **Running requires handbook access:**

```bash
harbor run -d actava-ai/chi-bench@v1.0.1 -a <agent> -m <model> -e HF_TOKEN=<approved-token>
```

Without a token the container exits early (code 78) with a clear message. The dataset (`actava/chi-bench`) is public and needs no token.

## Validation

- ✅ Secret-free build (public code + dataset), 4.74 GB
- ✅ No-token guard exits 78 with guidance
- ✅ With `HF_TOKEN`: handbook lands at `/workspace/skills/managed-care-operations-handbook/` (`SKILL.md` + `references/`, 1279 md), readable; server + 3 MCP boot
- ✅ Standard verifier + marathon session verifier both write `reward.json`
- ✅ Hub dataset published private, rev 2 (101 tasks)

## Follow-up

- Flip the hub dataset + tasks public when ready (`harbor dataset visibility actava-ai/chi-bench --public --cascade`). Even public, running needs an approved handbook token — a public *listing* + run-for-approved, consistent with the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)