### PR TITLE
Fix Harbor-hub runnability + correct run command (validated via real harbor run)

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,9 @@ Full flag-by-flag CLI reference: [`docs/cli.md`](docs/cli.md). Web walkthrough o
 
 ## Run from the Harbor hub (no source checkout)
 
-chi-Bench is also published to the [Harbor hub](https://hub.harborframework.com/datasets/actava-ai/chi-bench) as `actava-ai/chi-bench` (101 tasks). Each task ships a self-contained Dockerfile that Harbor builds on demand — cloning this repo and downloading the [fixtures dataset](https://huggingface.co/datasets/actava/chi-bench) at build — so you can run a trial without cloning anything yourself.
+chi-Bench is also published to the [Harbor hub](https://hub.harborframework.com/datasets/actava-ai/chi-bench) as `actava-ai/chi-bench` — **78 single-agent tasks** (75 single-domain + 3 marathon). Each task ships a self-contained Dockerfile that Harbor builds on demand — cloning this repo and downloading the [fixtures dataset](https://huggingface.co/datasets/actava/chi-bench) at build — so you can run a trial without cloning anything yourself.
+
+> **The 23 provider↔payer E2E tasks are *not* on the Harbor hub.** The E2E arena needs the two-agent `dual-pa-e2e` harness (provider phase → relay → payer phase), which a stock single-agent `harbor run` can't drive. Run E2E from this repo / the [HF dataset](https://huggingface.co/datasets/actava/chi-bench) with the `cb` CLI: `cb experiment run --dataset data/prior_auth_e2e/tasks/<id> --agent dual-pa-e2e --provider-model … --payer-model …` (see [`configs/experiments/table2_e2e_arena.yaml`](configs/experiments/table2_e2e_arena.yaml)).
 
 **Prerequisites:** Docker + the [Harbor CLI](https://github.com/harbor-framework/harbor), and an **approved HF token** for the gated [handbook](https://huggingface.co/datasets/actava/managed-care-operations-handbook) (the container downloads it at start; the fixtures dataset itself is public).
 
@@ -141,7 +143,7 @@ HF_TOKEN=<your-approved-hf-token> harbor run \
     -a claude-code -m anthropic/claude-opus-4-7 -y
 ```
 
-`HF_TOKEN` is read from your shell (or `--env-file`) and forwarded into the container — `-y` auto-confirms that prompt. Drop `-i …` to run all 101 tasks. Without an approved token the container exits early with a clear message. See [`docs/harbor-hub.md`](docs/harbor-hub.md) for how the fetch-at-build environment works and how the listing is regenerated/published. This path is for ad-hoc runs and discovery; the **paper-reproduction and leaderboard-submission flows use the `cb` CLI** described above.
+`HF_TOKEN` is read from your shell (or `--env-file`) and forwarded into the container — `-y` auto-confirms that prompt. Drop `-i …` to run all 78 tasks. Without an approved token the container exits early with a clear message. See [`docs/harbor-hub.md`](docs/harbor-hub.md) for how the fetch-at-build environment works and how the listing is regenerated/published. This path is for ad-hoc runs and discovery; the **paper-reproduction and leaderboard-submission flows use the `cb` CLI** described above.
 
 ### Reading the verifier output
 

--- a/README.md
+++ b/README.md
@@ -135,11 +135,13 @@ chi-Bench is also published to the [Harbor hub](https://hub.harborframework.com/
 **Prerequisites:** Docker + the [Harbor CLI](https://github.com/harbor-framework/harbor), and an **approved HF token** for the gated [handbook](https://huggingface.co/datasets/actava/managed-care-operations-handbook) (the container downloads it at start; the fixtures dataset itself is public).
 
 ```bash
-harbor run -d actava-ai/chi-bench@v1.0.1 -a claude-code -m anthropic/claude-opus-4-7 \
-    -e HF_TOKEN=<your-approved-hf-token>
+HF_TOKEN=<your-approved-hf-token> harbor run \
+    -d actava-ai/chi-bench@v1.0.1 \
+    -i actava-ai/pa_t016_t016_o001_p01_p2p_payer \
+    -a claude-code -m anthropic/claude-opus-4-7 -y
 ```
 
-Without an approved token the container exits early with a clear message. See [`docs/harbor-hub.md`](docs/harbor-hub.md) for how the fetch-at-build environment works and how the listing is regenerated/published. This path is for ad-hoc runs and discovery; the **paper-reproduction and leaderboard-submission flows use the `cb` CLI** described above.
+`HF_TOKEN` is read from your shell (or `--env-file`) and forwarded into the container — `-y` auto-confirms that prompt. Drop `-i …` to run all 101 tasks. Without an approved token the container exits early with a clear message. See [`docs/harbor-hub.md`](docs/harbor-hub.md) for how the fetch-at-build environment works and how the listing is regenerated/published. This path is for ad-hoc runs and discovery; the **paper-reproduction and leaderboard-submission flows use the `cb` CLI** described above.
 
 ### Reading the verifier output
 

--- a/docker/Dockerfile.harbor
+++ b/docker/Dockerfile.harbor
@@ -62,7 +62,7 @@ RUN git clone --depth 1 --branch "${CHI_BENCH_REF}" \
 # Harbor's docker environment build passes no build secrets, so the handbook
 # canNOT be fetched at build time — it is downloaded at RUNTIME by the wrapper
 # entrypoint using HF_TOKEN from the container env (see harbor-entrypoint).
-ARG CHI_BENCH_DATASET_REV=chi-bench-v1.0.0
+ARG CHI_BENCH_DATASET_REV=main
 RUN hf download actava/chi-bench --repo-type dataset --revision "${CHI_BENCH_DATASET_REV}" \
         --local-dir /tmp/chi-bench-data
 
@@ -96,7 +96,7 @@ RUN printf '%s\n' \
     '  TOKEN="${HF_TOKEN:-${HUGGING_FACE_HUB_TOKEN:-}}"' \
     '  if [ -z "$TOKEN" ]; then' \
     '    echo "harbor-entrypoint: gated handbook missing and no HF_TOKEN in env." >&2' \
-    '    echo "chi-bench is gated; run with: harbor run -d actava-ai/chi-bench ... -e HF_TOKEN=<approved-token>" >&2' \
+    '    echo "chi-bench is gated. Supply an approved token: HF_TOKEN=<token> harbor run -d actava-ai/chi-bench ... (or --env-file)." >&2' \
     '    exit 78' \
     '  fi' \
     '  echo "harbor-entrypoint: fetching gated handbook at runtime..." >&2' \

--- a/docs/harbor-hub.md
+++ b/docs/harbor-hub.md
@@ -33,13 +33,22 @@ tasks**.
 > entrypoint lets Harbor forward an approved `HF_TOKEN` as a normal runtime env
 > var instead.
 >
-> **Running therefore requires handbook access:**
+> **Running therefore requires handbook access.** Harbor resolves `${HF_TOKEN}`
+> (declared in each task's `task.toml [environment.env]`) from your shell or
+> `--env-file` and injects it into the container via the task's
+> `environment/docker-compose.yaml`. `-y` auto-confirms the "load from env"
+> prompt; `-i` selects one task (omit to run all 101):
 > ```bash
-> harbor run -d actava-ai/chi-bench@<tag> -a <agent> -m <model> \
->     -e HF_TOKEN=<your-approved-hf-token>
+> HF_TOKEN=<your-approved-hf-token> harbor run \
+>     -d actava-ai/chi-bench@<tag> \
+>     -i actava-ai/pa_t016_t016_o001_p01_p2p_payer \
+>     -a <agent> -m <model> -y
 > ```
-> Without an approved token the container exits early with a clear message.
-> The public dataset (`actava/chi-bench`) needs no token.
+> Note: the run flag is **not** `-e` (that is the environment *type*) and
+> `--ae`/`--ek` do **not** reach the entrypoint — the `${HF_TOKEN}` template +
+> compose `environment:` block is the only path that delivers it to PID1.
+> Without an approved token the container exits early (code 78). The public
+> dataset (`actava/chi-bench`) needs no token.
 
 ## What ships in a hub task (and what does not)
 

--- a/docs/harbor-hub.md
+++ b/docs/harbor-hub.md
@@ -37,7 +37,7 @@ tasks**.
 > (declared in each task's `task.toml [environment.env]`) from your shell or
 > `--env-file` and injects it into the container via the task's
 > `environment/docker-compose.yaml`. `-y` auto-confirms the "load from env"
-> prompt; `-i` selects one task (omit to run all 101):
+> prompt; `-i` selects one task (omit to run all 78):
 > ```bash
 > HF_TOKEN=<your-approved-hf-token> harbor run \
 >     -d actava-ai/chi-bench@<tag> \
@@ -68,7 +68,8 @@ Both write the binary reward to `/logs/verifier/reward.json`.
 ## Regenerating + publishing
 
 ```bash
-# 1. Export 101 self-contained Harbor task dirs from the dataset tree
+# 1. Export the 78 self-contained Harbor task dirs from the dataset tree
+#    (75 single-domain + 3 marathon; prior_auth_e2e is intentionally excluded)
 uv run python scripts/export_harbor_tasks.py \
     --data-root data --out logs/harbor_export --org actava-ai
 
@@ -77,13 +78,29 @@ cd logs/harbor_export
 uvx harbor auth login                       # one-time, GitHub flow
 uvx harbor init "actava-ai/chi-bench" --dataset --description "…" --author "actava-ai"
 uvx harbor add tasks --scan
-uvx harbor publish tasks --private          # publish the 101 task packages
+uvx harbor publish tasks --private          # publish the 78 task packages
 uvx harbor publish . -t v1.0.0 --private --no-tasks   # publish the dataset
 # verify the listing, then flip to public:
 #   uvx harbor dataset visibility actava-ai/chi-bench --public
 ```
 
-`--data-root` can point at a local HF clone of `actava/chi-bench`; it expects
-the `prior_auth_um/`, `prior_auth_provider/`, `care_management/`,
-`prior_auth_e2e/`, and `marathon/` families plus the optional `tasks.jsonl`
-metadata sidecar.
+`--data-root` can point at a local HF clone of `actava/chi-bench`; it reads the
+`prior_auth_um/`, `prior_auth_provider/`, `care_management/`, and `marathon/`
+families (plus the optional `tasks.jsonl` metadata sidecar). Per-task timeouts
+are copied from each source `task.toml`, so marathon sessions keep their long
+`agent=36000s` / `verifier=18000s` budgets.
+
+## E2E is not exported to the hub
+
+`prior_auth_e2e` (23 provider↔payer arena tasks) is deliberately **excluded**
+from the hub export. The arena needs the two-agent `dual-pa-e2e` harness
+(`chi_bench.experiment.agents.dual_pa_e2e_harness:DualPaE2EHarness`) which
+sequences a provider phase → relay → payer phase in one trial — a stock
+single-agent `harbor run` cannot drive it. Run E2E from this repo / the HF
+dataset instead:
+
+```bash
+cb experiment run --dataset data/prior_auth_e2e/tasks/<id> \
+    --agent dual-pa-e2e --provider-model <m> --payer-model <m>
+# or the full arena: ./scripts/run_table.sh table2   (configs/experiments/table2_e2e_arena.yaml)
+```

--- a/scripts/export_harbor_tasks.py
+++ b/scripts/export_harbor_tasks.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import argparse
 import json
 import shutil
+import tomllib
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -37,7 +38,10 @@ FAMILIES = {
     "prior_auth_um": ("prior_auth_um/tasks/*", "prior_auth_um"),
     "prior_auth_provider": ("prior_auth_provider/tasks/*", "prior_auth_provider"),
     "care_management": ("care_management/tasks/*", "care_management"),
-    "prior_auth_e2e": ("prior_auth_e2e/tasks/*", "prior_auth_e2e"),
+    # NOTE: prior_auth_e2e is intentionally NOT exported to the Harbor hub. The
+    # provider<->payer arena needs the two-agent `dual-pa-e2e` harness (provider
+    # phase -> relay -> payer phase), which a stock single-agent `harbor run`
+    # cannot drive. E2E runs via the source repo / cb CLI instead.
 }
 MARATHON = {
     "marathon/prior_auth_um": "marathon_prior_auth_um",
@@ -133,7 +137,15 @@ def load_meta(data_root: Path) -> dict[str, dict]:
     return out
 
 
-def render_task_toml(name: str, cb_task_id: str, domain: str, meta: dict) -> str:
+def render_task_toml(
+    name: str,
+    cb_task_id: str,
+    domain: str,
+    meta: dict,
+    *,
+    verifier_timeout: float,
+    agent_timeout: float,
+) -> str:
     title = meta.get("title", cb_task_id)
     excerpt = (meta.get("instruction_excerpt") or "").replace("\n", " ").strip()[:180]
     desc = f"chi-Bench {domain} task: {title}. {excerpt}".strip()
@@ -142,7 +154,6 @@ def render_task_toml(name: str, cb_task_id: str, domain: str, meta: dict) -> str
     if meta.get("task_kind"):
         kws.append(meta["task_kind"])
     kw_toml = ", ".join(f'"{k}"' for k in kws)
-    agent_timeout = float(meta.get("agent_timeout_sec", 900.0))
     return f"""\
 schema_version = "1.2"
 artifacts = []
@@ -161,7 +172,7 @@ dataset = "{HF_DATASET}"
 leaderboard = "{LEADERBOARD}"
 
 [verifier]
-timeout_sec = 1200.0
+timeout_sec = {verifier_timeout}
 
 [verifier.env]
 
@@ -201,6 +212,22 @@ url = "http://localhost:8200/mcp"
 """
 
 
+def read_source_timeouts(src: Path) -> tuple[float, float]:
+    """(verifier_timeout, agent_timeout) from the source task.toml.
+
+    Preserves the source's intent per task — single tasks are 1200/900, the
+    long-horizon marathon sessions are 18000/36000. Falls back to the single-
+    task defaults if the source omits them.
+    """
+    toml = src / "task.toml"
+    verifier, agent = 1200.0, 900.0
+    if toml.exists():
+        data = tomllib.loads(toml.read_text())
+        verifier = float(data.get("verifier", {}).get("timeout_sec", verifier))
+        agent = float(data.get("agent", {}).get("timeout_sec", agent))
+    return verifier, agent
+
+
 def emit_task(
     src: Path,
     out_dir: Path,
@@ -215,7 +242,13 @@ def emit_task(
     t = out_dir / task_id
     (t / "environment").mkdir(parents=True, exist_ok=True)
     (t / "tests").mkdir(parents=True, exist_ok=True)
-    (t / "task.toml").write_text(render_task_toml(name, cb_task_id, domain, meta))
+    verifier_timeout, agent_timeout = read_source_timeouts(src)
+    (t / "task.toml").write_text(
+        render_task_toml(
+            name, cb_task_id, domain, meta,
+            verifier_timeout=verifier_timeout, agent_timeout=agent_timeout,
+        )
+    )
     instr = src / "instruction.md"
     (t / "instruction.md").write_text(instr.read_text() if instr.exists() else f"# {task_id}\n")
     shutil.copyfile(DOCKERFILE, t / "environment" / "Dockerfile")

--- a/scripts/export_harbor_tasks.py
+++ b/scripts/export_harbor_tasks.py
@@ -45,6 +45,30 @@ MARATHON = {
     "marathon/care_management": "marathon_care_management",
 }
 
+# Harbor injects task env into the container ONLY through a task-shipped
+# docker-compose.yaml (base + build compose carry no `environment:` block).
+# CHI_BENCH_TASK_ID + HF_TOKEN are resolved from task.toml [environment.env]
+# into the compose subprocess env, then substituted here into the container.
+COMPOSE_YAML = """\
+services:
+  main:
+    environment:
+      CHI_BENCH_TASK_ID: "${CHI_BENCH_TASK_ID}"
+      HF_TOKEN: "${HF_TOKEN:-}"
+    # Gate `compose up --wait` on server readiness. The entrypoint fetches the
+    # gated handbook, boots `cb serve`, and waits for all 3 MCP servers before
+    # backgrounding; without a healthcheck Harbor proceeds while it is still
+    # booting and the verifier hits a connection-refused on :8100. Probe the
+    # payer MCP port (last to come up) so the agent/verifier only start once
+    # the world server is actually serving.
+    healthcheck:
+      test: ["CMD", "/workspace/.venv/bin/python", "-c", "import socket; socket.create_connection(('localhost', 8100), 2)"]
+      interval: 5s
+      timeout: 5s
+      retries: 48
+      start_period: 240s
+"""
+
 # Standard single-task verifier. CHI_BENCH_TASK_ID is in the persistent env
 # (task.toml [environment.env]); the scoring contract is baked at the
 # deterministic per-task path (the entrypoint deliberately does NOT expose
@@ -58,6 +82,7 @@ set -euo pipefail
 . /workspace/.venv/bin/activate
 mkdir -p /logs/verifier
 python -m chi_bench.verifier.task_runtime verify \\
+    --verifier-host localhost \\
     --expectations-path "/opt/chi-bench/tasks/${CHI_BENCH_TASK_ID}/fixtures/expectations.json"
 """
 
@@ -69,6 +94,7 @@ set -euo pipefail
 . /workspace/.venv/bin/activate
 mkdir -p /logs/verifier
 python -m chi_bench.verifier.session_verifier \\
+    --verifier-host localhost \\
     --fixtures-dir "/opt/chi-bench/tasks/${CHI_BENCH_TASK_ID}/fixtures" \\
     --output-dir /logs/verifier
 """
@@ -153,6 +179,10 @@ allow_internet = true
 
 [environment.env]
 CHI_BENCH_TASK_ID = "{cb_task_id}"
+# Gated handbook token. Harbor resolves ${{VAR}} from the host env (or --env-file)
+# into the container env at start, where the wrapper entrypoint reads it. Supply
+# it via: HF_TOKEN=... harbor run ...  (or --env-file). --ae/--ek do NOT reach PID1.
+HF_TOKEN = "${{HF_TOKEN:-}}"
 
 [[environment.mcp_servers]]
 name = "chi-bench-provider"
@@ -189,6 +219,7 @@ def emit_task(
     instr = src / "instruction.md"
     (t / "instruction.md").write_text(instr.read_text() if instr.exists() else f"# {task_id}\n")
     shutil.copyfile(DOCKERFILE, t / "environment" / "Dockerfile")
+    (t / "environment" / "docker-compose.yaml").write_text(COMPOSE_YAML)
     ts = t / "tests" / "test.sh"
     ts.write_text(SESSION_TEST_SH if session else TEST_SH)
     ts.chmod(0o755)

--- a/scripts/export_harbor_tasks.py
+++ b/scripts/export_harbor_tasks.py
@@ -109,7 +109,7 @@ Hugging Face at build time. No registry image, no repo checkout required.
 The managed-care handbook is gated; the wrapper entrypoint downloads it at
 container start, so you must pass an approved HF token at run time:
 
-    harbor run -d {org}/chi-bench@<tag> -a <agent> -m <model> -e HF_TOKEN=<token>
+    HF_TOKEN=<token> harbor run -d {org}/chi-bench@<tag> -i {org}/<task> -a <agent> -m <model> -y
 
 This builds the image, downloads the handbook, boots the chi-Bench MCP servers,
 runs your agent, then scores with the baked-in verifier.


### PR DESCRIPTION
Follow-up to #5/#6. An actual end-to-end `harbor run` (nop agent) surfaced four bugs that manual `docker build`/`docker run` validation missed. All fixed and **verified end-to-end** — the trial completes with `errored: 0` and a real `reward.json` written by the verifier and read by Harbor.

## Bugs fixed
1. **Build 401** — `CHI_BENCH_DATASET_REV=chi-bench-v1.0.0` references a HF revision that doesn't exist (the dataset has no tags). → default `main`.
2. **Env not injected** — a Dockerfile-only task can't get `CHI_BENCH_TASK_ID`/`HF_TOKEN` into the container; Harbor injects task `[environment.env]` only through a task-shipped `environment/docker-compose.yaml` with an `environment:` block. Added.
3. **Verifier DNS** — `chi-bench-server` doesn't resolve in the shared verifier exec. → `--verifier-host localhost`.
4. **Boot race** — `compose up --wait` returned before `cb serve` was listening (connection refused). → compose healthcheck on the payer MCP `:8100`.

## Run command corrected
The flag is **not** `-e` (that's the environment *type*); `--ae`/`--ek` don't reach PID1 either. `HF_TOKEN` is delivered via the `${HF_TOKEN}` template in `[environment.env]` + the compose `environment:` block, read from the shell/`--env-file`:

```bash
HF_TOKEN=<approved-token> harbor run \
    -d actava-ai/chi-bench@v1.0.1 \
    -i actava-ai/pa_t016_t016_o001_p01_p2p_payer \
    -a claude-code -m anthropic/claude-opus-4-7 -y
```

README (`Run from the Harbor hub`), `docs/harbor-hub.md`, and the generated per-task READMEs updated. Hub dataset republished (rev 9, all fixes live). HF dataset card updated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)