### PR TITLE
Harbor hub: real-agent validated (env forwarding, tag pin, model-id fix)

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ chi-Bench is also published to the [Harbor hub](https://hub.harborframework.com/
 HF_TOKEN=<your-approved-hf-token> harbor run \
     -d actava-ai/chi-bench@v1.0.1 \
     -i actava-ai/pa_t016_t016_o001_p01_p2p_payer \
-    -a claude-code -m anthropic/claude-opus-4-7 -y
+    -a claude-code -m claude-opus-4-7 -y
 ```
 
 `HF_TOKEN` is read from your shell (or `--env-file`) and forwarded into the container — `-y` auto-confirms that prompt. Drop `-i …` to run all 78 tasks. Without an approved token the container exits early with a clear message. See [`docs/harbor-hub.md`](docs/harbor-hub.md) for how the fetch-at-build environment works and how the listing is regenerated/published. This path is for ad-hoc runs and discovery; the **paper-reproduction and leaderboard-submission flows use the `cb` CLI** described above.

--- a/docker/Dockerfile.harbor
+++ b/docker/Dockerfile.harbor
@@ -62,7 +62,7 @@ RUN git clone --depth 1 --branch "${CHI_BENCH_REF}" \
 # Harbor's docker environment build passes no build secrets, so the handbook
 # canNOT be fetched at build time — it is downloaded at RUNTIME by the wrapper
 # entrypoint using HF_TOKEN from the container env (see harbor-entrypoint).
-ARG CHI_BENCH_DATASET_REV=main
+ARG CHI_BENCH_DATASET_REV=chi-bench-v1.0.0
 RUN hf download actava/chi-bench --repo-type dataset --revision "${CHI_BENCH_DATASET_REV}" \
         --local-dir /tmp/chi-bench-data
 

--- a/docs/harbor-hub.md
+++ b/docs/harbor-hub.md
@@ -47,6 +47,11 @@ tasks**.
 > Note: the run flag is **not** `-e` (that is the environment *type*) and
 > `--ae`/`--ek` do **not** reach the entrypoint — the `${HF_TOKEN}` template +
 > compose `environment:` block is the only path that delivers it to PID1.
+>
+> For `-a claude-code`, pass the **bare** Anthropic model id (e.g.
+> `claude-opus-4-7`, `claude-sonnet-4-6`) — the `anthropic/` prefix 404s because
+> `harbor run` forwards the model verbatim to the native CLI. The `vendor/`
+> prefix form is only for OpenRouter-routed agents (codex / openai-agents).
 > Without an approved token the container exits early (code 78). The public
 > dataset (`actava/chi-bench`) needs no token.
 

--- a/scripts/export_harbor_tasks.py
+++ b/scripts/export_harbor_tasks.py
@@ -59,6 +59,26 @@ services:
     environment:
       CHI_BENCH_TASK_ID: "${CHI_BENCH_TASK_ID}"
       HF_TOKEN: "${HF_TOKEN:-}"
+      # Model credentials + toggles forwarded into the container so the
+      # in-container server (p2p / patient simulators) and the WorkspaceJudge
+      # verifier can call their models. Resolved from the runner's env (or
+      # --env-file). Empty defaults => only set when the runner provides them.
+      ANTHROPIC_API_KEY: "${ANTHROPIC_API_KEY:-}"
+      OPENAI_API_KEY: "${OPENAI_API_KEY:-}"
+      OPENAI_BASE_URL: "${OPENAI_BASE_URL:-}"
+      OPENROUTER_API_KEY: "${OPENROUTER_API_KEY:-}"
+      GEMINI_API_KEY: "${GEMINI_API_KEY:-}"
+      XAI_API_KEY: "${XAI_API_KEY:-}"
+      CLAUDE_CODE_OAUTH_TOKEN: "${CLAUDE_CODE_OAUTH_TOKEN:-}"
+      CHI_BENCH_JUDGE_MODEL: "${CHI_BENCH_JUDGE_MODEL:-}"
+      CHI_BENCH_JUDGE_TIMEOUT_S: "${CHI_BENCH_JUDGE_TIMEOUT_S:-}"
+      CHI_BENCH_JUDGE_NUM_VOTES: "${CHI_BENCH_JUDGE_NUM_VOTES:-}"
+      CHI_BENCH_PATIENT_SIM_MODEL: "${CHI_BENCH_PATIENT_SIM_MODEL:-}"
+      CHI_BENCH_P2P_SIMULATOR_MODEL: "${CHI_BENCH_P2P_SIMULATOR_MODEL:-}"
+      CHI_BENCH_TOOL_MODE: "${CHI_BENCH_TOOL_MODE:-}"
+      CHI_BENCH_MCP_TOOL_SEP: "${CHI_BENCH_MCP_TOOL_SEP:-}"
+      CHI_BENCH_PAYER_MCP_PROFILE: "${CHI_BENCH_PAYER_MCP_PROFILE:-}"
+      CHI_BENCH_SKILLS_ABLATE: "${CHI_BENCH_SKILLS_ABLATE:-}"
     # Gate `compose up --wait` on server readiness. The entrypoint fetches the
     # gated handbook, boots `cb serve`, and waits for all 3 MCP servers before
     # backgrounding; without a healthcheck Harbor proceeds while it is still
@@ -194,6 +214,26 @@ CHI_BENCH_TASK_ID = "{cb_task_id}"
 # into the container env at start, where the wrapper entrypoint reads it. Supply
 # it via: HF_TOKEN=... harbor run ...  (or --env-file). --ae/--ek do NOT reach PID1.
 HF_TOKEN = "${{HF_TOKEN:-}}"
+# Model credentials + toggles for the in-container server simulators and the
+# WorkspaceJudge verifier. resolve_env_vars() reads ${{VAR}} from the runner's
+# env into the compose subprocess env; the compose `environment:` block then
+# substitutes them into the container. Empty default => optional.
+ANTHROPIC_API_KEY = "${{ANTHROPIC_API_KEY:-}}"
+OPENAI_API_KEY = "${{OPENAI_API_KEY:-}}"
+OPENAI_BASE_URL = "${{OPENAI_BASE_URL:-}}"
+OPENROUTER_API_KEY = "${{OPENROUTER_API_KEY:-}}"
+GEMINI_API_KEY = "${{GEMINI_API_KEY:-}}"
+XAI_API_KEY = "${{XAI_API_KEY:-}}"
+CLAUDE_CODE_OAUTH_TOKEN = "${{CLAUDE_CODE_OAUTH_TOKEN:-}}"
+CHI_BENCH_JUDGE_MODEL = "${{CHI_BENCH_JUDGE_MODEL:-}}"
+CHI_BENCH_JUDGE_TIMEOUT_S = "${{CHI_BENCH_JUDGE_TIMEOUT_S:-}}"
+CHI_BENCH_JUDGE_NUM_VOTES = "${{CHI_BENCH_JUDGE_NUM_VOTES:-}}"
+CHI_BENCH_PATIENT_SIM_MODEL = "${{CHI_BENCH_PATIENT_SIM_MODEL:-}}"
+CHI_BENCH_P2P_SIMULATOR_MODEL = "${{CHI_BENCH_P2P_SIMULATOR_MODEL:-}}"
+CHI_BENCH_TOOL_MODE = "${{CHI_BENCH_TOOL_MODE:-}}"
+CHI_BENCH_MCP_TOOL_SEP = "${{CHI_BENCH_MCP_TOOL_SEP:-}}"
+CHI_BENCH_PAYER_MCP_PROFILE = "${{CHI_BENCH_PAYER_MCP_PROFILE:-}}"
+CHI_BENCH_SKILLS_ABLATE = "${{CHI_BENCH_SKILLS_ABLATE:-}}"
 
 [[environment.mcp_servers]]
 name = "chi-bench-provider"


### PR DESCRIPTION
Validated the Harbor-hub path **end-to-end with a real `claude-code` agent** (not just `nop`): `errored: 0`, **40 MCP tool calls**, 2.56M in / 25K out tokens (\$1.51), and the WorkspaceJudge scored a real trajectory (`md_review 3/4`, `cross_stage 2/2`, `outcome 0/2` → fractional 0.625, binary 0.0).

## Changes
- **`docker/Dockerfile.harbor`**: pin `CHI_BENCH_DATASET_REV=chi-bench-v1.0.0`. The tag now exists on the HF dataset (cut as part of fixing the `cb` setup flow), so the hub build is reproducible and matches the `cb`/source-repo pin instead of floating `main`.
- **`scripts/export_harbor_tasks.py`**: forward model credentials + judge/simulator toggles into the container via `[environment.env]` + the compose `environment:` block (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `OPENROUTER_API_KEY`, `GEMINI_API_KEY`, `CLAUDE_CODE_OAUTH_TOKEN`, `CHI_BENCH_JUDGE_MODEL`, `CHI_BENCH_P2P_SIMULATOR_MODEL`, …), mirroring chi-bench's own `docker_env` forwarding. Without this the in-container simulators and the verifier's LLM judge had no keys.
- **Docs** (README + `docs/harbor-hub.md`): hub run examples use the **bare** Anthropic model id for `claude-code` (`-m claude-opus-4-7`). The `anthropic/` prefix 404s because `harbor run` forwards the model verbatim to the native CLI; the `vendor/` prefix is only for OpenRouter-routed agents.

## Related (already live, not in this PR)
- HF dataset: `chi-bench-v1.0.0` tag cut → fixes the `cb` setup flow (`huggingface-cli download --revision chi-bench-v1.0.0`).
- Hub dataset republished (rev 14+) with the env forwarding; HF card + hub description updated with the bare model id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)