### PR TITLE
Enable GLM-5.2 + Sonnet-5 chi-bench submissions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,6 +157,12 @@ Configs:
 - **Dataset version pin** lives at `data/.chi-bench-version` and must match the submission YAML's
   `dataset.version`. `cb submission validate` (preflight) rejects mismatches. `cb data download`
   writes the pin in one step; the raw `huggingface-cli download` path needs `echo "$REV" > data/.chi-bench-version`.
+- **Model-id convention for `claude-code`:** `cb` configs/submissions pass `anthropic/<bare-id>`
+  (e.g. `anthropic/claude-fable-5`); Harbor's harness strips the vendor prefix and exports
+  `ANTHROPIC_MODEL=<bare-id>` to the claude CLI. Bare ids are only needed for raw `harbor run`
+  against hub-exported tasks, where `anthropic/<id>` 404s (commit 769744a). New models also need
+  a `configs/prices.yaml` entry (input/output/cache $ per 1M; cache = 0.1× input) or
+  `scripts/aggregate.py` cost columns come out empty.
 - **`/fixtures` is NOT exposed to the agent** as a readable mount — expectations, scoring contracts,
   and manifests are reserved for the verifier. The entrypoint exposes raw artifacts via
   `/workspace/raw/artifacts/` except for `*_new_referral_provider` tasks, where the chart is
@@ -170,6 +176,12 @@ Configs:
   so live-judge and docker-build smokes are opt-in via `-m`.
 - **Modal profile.** `cb experiment run -e modal` defaults to profile `actava`; pass
   `--modal-profile ''` to skip Modal preflight, or `MODAL_PROFILE=<name>` for a named profile.
+- **Agent-phase failures: read `trials/<name>/agent/claude-code.txt` tail first.** The stream-json
+  log carries the raw API error + request_id; `NonZeroAgentExitCodeError` alone says nothing.
+  Known case: Fable 5 (`claude-fable-5`) 400s with `model_not_available` ("organization or
+  workspace must have data retention enabled") unless the org has data retention on — an
+  Anthropic Console setting, not a harness/config bug. Reproduce with a bare curl before
+  blaming the pipeline.
 
 ## Subdirectory note
 

--- a/configs/prices.yaml
+++ b/configs/prices.yaml
@@ -34,6 +34,13 @@ prices:
   # ~35% more tokens for the same fixed text vs earlier Opus versions; the
   # per-token rate is identical to Opus 4.6, but ROI denominator on 4.7 runs
   # skews higher accordingly.
+  anthropic/claude-sonnet-5:
+    # Standard rate $3/$15 per 1M, same sticker as sonnet-4-6. Introductory
+    # pricing is $2/$10 (cache 0.20) through 2026-08-31 — swap in input:2.00/
+    # output:10.00/cache:0.20 if you want the intro rate for runs before then.
+    input: 3.00
+    output: 15.00
+    cache: 0.30          # 0.1x input (Anthropic standard)
   anthropic/claude-opus-4-7:
     input: 5.00
     output: 25.00
@@ -85,6 +92,14 @@ prices:
   # third-party slugs; we assume 10% of input as an industry-typical
   # cached-discount heuristic. Revisit once a real provider number shows up
   # in `result.json.agent_result` for these runs.
+  # z-ai/glm-5.2 rates verified on openrouter.ai (2026-06-30): $0.93 in / $3.00 out
+  # per 1M, 1M context. OpenRouter publishes no explicit cache-read rate, so cache
+  # is the usual 10%-of-input heuristic (revisit if a real provider number appears
+  # in result.json.agent_result).
+  z-ai/glm-5.2:
+    input: 0.93
+    output: 3.00
+    cache: 0.093         # assumed 10% of input (OpenRouter cache rate TBD)
   qwen/qwen3-max:
     input: 0.78
     output: 3.90

--- a/configs/submissions/glm-5-2-openai-agents.yaml
+++ b/configs/submissions/glm-5-2-openai-agents.yaml
@@ -1,0 +1,31 @@
+# GLM-5.2 + openai-agents (OpenAI Agents SDK, routed to OpenRouter) on Modal.
+# See configs/submission_example.yaml for field docs.
+schema: chi-bench/submission/v1
+
+submission:
+  # Slug-safe id (no '.'); the model id below keeps the real "5.2".
+  id: glm-5-2-openai-agents
+  # Adjust team/contact before a real leaderboard submission.
+  team: Actava
+  contact: dark.savi@gmail.com
+  agent: openai-agents
+  # Non-OpenAI vendor prefix => the openai-agents harness auto-routes to OpenRouter:
+  # it forwards OPENROUTER_API_KEY as the SDK key, sets base-url to openrouter.ai, and
+  # passes the model id verbatim. Requires OPENROUTER_API_KEY in .env (plus ANTHROPIC_API_KEY
+  # for the judge). NOTE: no "openrouter/" prefix here — that prefix is only for the
+  # openclaw/hermes/deepagents harnesses; openai-agents takes the bare "<vendor>/<id>" slug.
+  model: z-ai/glm-5.2
+  notes: |
+    GLM-5.2 via the OpenAI Agents SDK harness, routed through OpenRouter.
+
+run:
+  environment: modal
+  n_attempts: 1
+  concurrency: 5
+  max_retries: 2
+  timeout_multiplier: 2.0
+  env_file: .env
+
+dataset:
+  version: chi-bench-v1.0.0
+  domains: [pa_provider, pa_um, cm]

--- a/configs/submissions/sonnet-5-claude-code.yaml
+++ b/configs/submissions/sonnet-5-claude-code.yaml
@@ -1,0 +1,27 @@
+# Claude Sonnet 5 + claude-code on Modal. See configs/submission_example.yaml for field docs.
+schema: chi-bench/submission/v1
+
+submission:
+  id: sonnet-5-claude-code
+  # Adjust team/contact before a real leaderboard submission.
+  team: Actava
+  contact: dark.savi@gmail.com
+  agent: claude-code
+  # Vendor-prefixed per repo convention; Harbor strips the prefix and exports
+  # ANTHROPIC_MODEL=claude-sonnet-5 to the claude CLI. Requires ANTHROPIC_API_KEY in .env
+  # (also the judge key, claude-opus-4-7).
+  model: anthropic/claude-sonnet-5
+  notes: |
+    Claude Sonnet 5 via the stock claude-code harness (MCP tools).
+
+run:
+  environment: modal
+  n_attempts: 1
+  concurrency: 5
+  max_retries: 2
+  timeout_multiplier: 2.0
+  env_file: .env
+
+dataset:
+  version: chi-bench-v1.0.0
+  domains: [pa_provider, pa_um, cm]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -64,6 +64,15 @@ COPY src/ /workspace/src/
 RUN uv sync --no-dev \
     && /workspace/.venv/bin/playwright install --with-deps chromium
 
+# healthverse -> chi_bench compatibility shim (docker/shims/healthverse).
+# The published chi-bench dataset's verifier entrypoints invoke
+# `python -m healthverse.verifier.task_runtime` (and marathon's
+# `...session_verifier`), expecting a `healthverse` package in the image. src/
+# was renamed healthverse -> chi_bench, so install a `healthverse` alias package
+# whose __path__ is chi_bench's. The build fails fast if the alias can't resolve.
+COPY docker/shims/healthverse /workspace/.venv/lib/python3.12/site-packages/healthverse
+RUN /workspace/.venv/bin/python -c "import importlib.util as u; assert u.find_spec('healthverse.verifier.task_runtime') and u.find_spec('healthverse.verifier.session_verifier'); print('healthverse alias OK')"
+
 # CI build target: stops here, before any task data is copied. This stage
 # is what CI uses to verify the Dockerfile parses and the dependency
 # install succeeds without needing the data/ tree in the build context.
@@ -78,7 +87,7 @@ FROM base AS runtime
 # per-trial upload step.
 # Cache-buster: bump on each cohort backfill so force_build=True
 # actually invalidates the cached image.
-ARG DATASET_CACHE_BUST=2026-05-11-oss-v1
+ARG DATASET_CACHE_BUST=2026-06-30-healthverse-alias
 COPY data/prior_auth_provider/shared/worlds /opt/chi-bench/worlds
 COPY data/prior_auth_provider/tasks /opt/chi-bench/tasks
 COPY data/prior_auth_um/tasks /opt/chi-bench/tasks

--- a/docker/shims/healthverse/__init__.py
+++ b/docker/shims/healthverse/__init__.py
@@ -1,0 +1,24 @@
+"""Image-level compatibility alias: ``healthverse`` -> ``chi_bench``.
+
+The published actava/chi-bench dataset (tag ``chi-bench-v1.0.0``) invokes the
+verifier as ``python -m healthverse.verifier.task_runtime`` (and marathon's
+``...session_verifier``), and each task's ``tests/test.sh`` states the shared
+verifier logic "lives in the packaged healthverse module inside the main
+container image". The package was renamed ``healthverse`` -> ``chi_bench`` in
+``src/`` without republishing the dataset, which makes the in-sandbox verifier
+fail with ``ModuleNotFoundError: No module named 'healthverse'``.
+
+This shim re-points ``healthverse`` at the installed ``chi_bench`` package: its
+``__path__`` is chi_bench's, so ``healthverse.verifier.<mod>`` loads
+``chi_bench/verifier/<mod>.py``. It is baked into the Docker/Modal image only
+(the host code keeps the clean ``chi_bench`` name). Remove once the dataset is
+regenerated under the ``chi_bench`` module name.
+"""
+
+from __future__ import annotations
+
+import chi_bench as _chi_bench
+
+# Submodule search path = chi_bench's, so healthverse.verifier.task_runtime
+# resolves to chi_bench/verifier/task_runtime.py.
+__path__ = list(_chi_bench.__path__)

--- a/src/chi_bench/aggregator.py
+++ b/src/chi_bench/aggregator.py
@@ -110,10 +110,13 @@ def _parse_trial(result_path: Path) -> Trial | None:
         agent=agent,
         model=model,
         reward=reward,
-        input_tokens=int(ar.get("input_tokens", 0)),
-        output_tokens=int(ar.get("output_tokens", 0)),
-        cache_tokens=int(ar.get("n_cache_tokens", 0)),
-        wall_clock_seconds=float(ar.get("wall_clock_seconds", 0.0)),
+        # `or 0` (not a get-default) so an explicit null value — emitted by the
+        # openai-agents/OpenRouter path, which leaves cost/token fields None —
+        # coerces to 0 instead of crashing int(None)/float(None).
+        input_tokens=int(ar.get("input_tokens") or 0),
+        output_tokens=int(ar.get("output_tokens") or 0),
+        cache_tokens=int(ar.get("n_cache_tokens") or 0),
+        wall_clock_seconds=float(ar.get("wall_clock_seconds") or 0.0),
     )
 
 

--- a/src/chi_bench/experiment/modal_env.py
+++ b/src/chi_bench/experiment/modal_env.py
@@ -108,11 +108,16 @@ def _terminate_tracked_sandboxes() -> None:
 # forwarded — empty strings would defeat the `os.environ.get(KEY) or DEFAULT`
 # patterns inside chi_bench (e.g. judge.timeout_s).
 SERVER_ENV_FORWARD_KEYS: tuple[str, ...] = (
-    # Workspace judge — Claude CLI spawned by WorkspaceJudge inside the
-    # sandbox authenticates via this OAuth token (mirrors the
-    # `# judge-harness:compose` block in each task's docker-compose.yaml).
-    # Without this, the CLI prompts interactively and the judge session
-    # fails immediately; `IS_SANDBOX=1` alone isn't sufficient.
+    # Workspace judge — the Claude CLI spawned by WorkspaceJudge inside the
+    # sandbox authenticates via ANTHROPIC_API_KEY by default (forwarded below;
+    # see verifier/judge/claude_runner._ensure_authenticated, which treats a
+    # present key as the auth method and skips the `claude auth status` probe).
+    # This OAuth token stays forwarded as a fallback for hosts that judge via a
+    # logged-in Claude Code session instead of a key (mirrors the
+    # `# judge-harness:compose` block in each task's docker-compose.yaml); when
+    # both are present the API key wins. With neither, the CLI prompts
+    # interactively and the judge fails immediately (`IS_SANDBOX=1` alone isn't
+    # sufficient).
     "CLAUDE_CODE_OAUTH_TOKEN",
     # Semantic judge (required for contract_v3 verifier)
     "OPENAI_API_KEY",
@@ -120,7 +125,7 @@ SERVER_ENV_FORWARD_KEYS: tuple[str, ...] = (
     "CHI_BENCH_JUDGE_MODEL",
     "CHI_BENCH_JUDGE_TIMEOUT_S",
     "CHI_BENCH_JUDGE_NUM_VOTES",
-    # Patient/P2P simulators (various providers)
+    # Patient/P2P simulators (various providers) + workspace judge default auth
     "ANTHROPIC_API_KEY",
     "GEMINI_API_KEY",
     "GROK_API_KEY",

--- a/src/chi_bench/verifier/judge/claude_runner.py
+++ b/src/chi_bench/verifier/judge/claude_runner.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import re
 import subprocess
 import tempfile
@@ -493,6 +494,18 @@ class ClaudeAgentRunner:
     def _ensure_authenticated(self) -> None:
         if self._auth_checked:
             return
+        # Default auth path: ANTHROPIC_API_KEY (or ANTHROPIC_AUTH_TOKEN). The
+        # judge is documented to run on the Anthropic API key (docs/judge.md),
+        # and inside a sandbox there is normally no logged-in Claude Code
+        # session — `claude auth status` reports loggedIn:false for a bare env
+        # key and would raise below. Recognise the key as the auth method and
+        # skip the probe; _subprocess_env then keeps it in the CLI env (the
+        # api_key branch is not stripped).
+        if os.environ.get("ANTHROPIC_API_KEY") or os.environ.get("ANTHROPIC_AUTH_TOKEN"):
+            self._auth_checked = True
+            self._auth_logged_in = True
+            self._auth_method = "api_key"
+            return
         try:
             result = subprocess.run(
                 ["claude", "auth", "status"],
@@ -511,7 +524,8 @@ class ClaudeAgentRunner:
         if payload.get("loggedIn") is False:
             auth_method = payload.get("authMethod") or "unknown"
             raise ClaudeAuthError(
-                "Claude CLI is not authenticated. Run `claude auth login` and retry. "
+                "Claude CLI is not authenticated and no ANTHROPIC_API_KEY is set. "
+                "Set ANTHROPIC_API_KEY, or run `claude auth login`, then retry. "
                 f"(authMethod={auth_method})"
             )
         self._auth_checked = True
@@ -659,8 +673,6 @@ class ClaudeAgentRunner:
 
     def _subprocess_env(self) -> dict[str, str] | None:
         """Build env dict that ensures CLAUDE_CODE_MAX_OUTPUT_TOKENS is set."""
-        import os
-
         existing = os.environ.get("CLAUDE_CODE_MAX_OUTPUT_TOKENS")
         target = self.max_output_tokens or (None if existing else self.DEFAULT_MAX_OUTPUT_TOKENS)
         env: dict[str, str] | None
@@ -670,9 +682,10 @@ class ClaudeAgentRunner:
             env = os.environ.copy()
             env["CLAUDE_CODE_MAX_OUTPUT_TOKENS"] = str(target)
 
-        # Prefer the local Claude Code session/OAuth auth path when the CLI is
-        # already logged in. This avoids repo-level API keys silently taking
-        # precedence and routing synthesis through the wrong quota pool.
+        # Fall back to a logged-in Claude Code session/OAuth path only when no
+        # API key is present — _ensure_authenticated sets _auth_method="api_key"
+        # whenever ANTHROPIC_API_KEY/ANTHROPIC_AUTH_TOKEN is set, so with a key
+        # the judge keeps it in the CLI env and scores on api.anthropic.com.
         if self._auth_logged_in and self._auth_method not in {
             "api_key",
             "api-key",

--- a/tests/unit/test_judge_env_isolation.py
+++ b/tests/unit/test_judge_env_isolation.py
@@ -50,3 +50,50 @@ def test_subprocess_env_no_anthropic_base_url_unset_path(
     # ANTHROPIC_BASE_URL must not appear.
     if env is not None:
         assert "ANTHROPIC_BASE_URL" not in env
+
+
+# ─── ANTHROPIC_API_KEY as the default judge auth path ────────────────────────
+
+
+@pytest.mark.parametrize("key_var", ["ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN"])
+def test_ensure_authenticated_prefers_api_key_without_probe(
+    runner: ClaudeAgentRunner, monkeypatch: pytest.MonkeyPatch, key_var: str
+) -> None:
+    """A present ANTHROPIC_API_KEY/AUTH_TOKEN short-circuits auth: no CLI probe,
+    no ClaudeAuthError, and the auth method is recorded as ``api_key`` so
+    _subprocess_env keeps the key for the judge subprocess."""
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_AUTH_TOKEN", raising=False)
+    monkeypatch.setenv(key_var, "sk-test-key")
+
+    # The `claude auth status` probe must NOT run when a key is present.
+    def _fail_if_called(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("claude auth status probe should be skipped when a key is set")
+
+    monkeypatch.setattr(
+        "chi_bench.verifier.judge.claude_runner.subprocess.run", _fail_if_called
+    )
+
+    runner._ensure_authenticated()
+
+    assert runner._auth_logged_in is True
+    assert runner._auth_method == "api_key"
+
+
+def test_api_key_survives_into_judge_env_after_auth(
+    runner: ClaudeAgentRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """End-to-end of the real flow: once auth marks api_key, the key is kept in
+    the judge subprocess env (the OAuth-preference strip is skipped)."""
+    monkeypatch.delenv("ANTHROPIC_AUTH_TOKEN", raising=False)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-judge-key")
+    monkeypatch.setattr(
+        "chi_bench.verifier.judge.claude_runner.subprocess.run",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("probe must be skipped")),
+    )
+
+    runner._ensure_authenticated()
+    env = runner._subprocess_env()
+
+    assert env is not None
+    assert env.get("ANTHROPIC_API_KEY") == "sk-judge-key"

--- a/tests/unit/test_judge_env_isolation.py
+++ b/tests/unit/test_judge_env_isolation.py
@@ -70,9 +70,7 @@ def test_ensure_authenticated_prefers_api_key_without_probe(
     def _fail_if_called(*_args: object, **_kwargs: object) -> None:
         raise AssertionError("claude auth status probe should be skipped when a key is set")
 
-    monkeypatch.setattr(
-        "chi_bench.verifier.judge.claude_runner.subprocess.run", _fail_if_called
-    )
+    monkeypatch.setattr("chi_bench.verifier.judge.claude_runner.subprocess.run", _fail_if_called)
 
     runner._ensure_authenticated()
 


### PR DESCRIPTION
## Enable GLM-5.2 + Sonnet-5 chi-bench submissions

Infra fixes + configs discovered while producing the **GLM-5.2** (openai-agents) and **Claude Sonnet 5** (claude-code) leaderboard submissions. The four commits are independent and empirically validated — both submissions built, graded, and passed the leaderboard CI validator ([actava-ai/leaderboard#11](https://github.com/actava-ai/leaderboard/pull/11), [#12](https://github.com/actava-ai/leaderboard/pull/12)).

### Commits
- **fix(aggregator)** — `int(None)`/`float(None)` crashed `_parse_trial` during `cb submission prepare`, because the openai-agents/OpenRouter path leaves cost/token fields `null`. Coerce with `or 0`.
- **fix(judge)** — WorkspaceJudge's Claude CLI runs in a Modal sandbox with no logged-in session; `claude auth status` reported `loggedIn:false` for a bare env key and raised. Recognise `ANTHROPIC_API_KEY`/`ANTHROPIC_AUTH_TOKEN` as the auth method, skip the probe, and keep the key in the CLI env so the judge scores on `api.anthropic.com`. `modal_env` forwards the key. Adds `test_judge_env_isolation` (5 tests).
- **fix(docker)** — the published dataset's verifier entrypoints invoke `python -m healthverse.verifier.*`, but `src/` was renamed `healthverse` → `chi_bench`. Install a `healthverse` alias package (path → `chi_bench`); the build fails fast if it can't resolve.
- **chore(submissions)** — cost rates for `anthropic/claude-sonnet-5` and `z-ai/glm-5.2`; the two run configs under `configs/submissions/`; `CLAUDE.md` notes (claude-code model-id convention, the prices requirement, the Fable-5 data-retention 400).

### Validation
- `ruff check` clean; `pytest tests/unit/test_judge_env_isolation.py` → 5 passed.
- Both submissions produced valid packets that passed the leaderboard `validate` CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
